### PR TITLE
Update README with feature and deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # EcoShopper
+
+EcoShopper is an early stage project focused on providing environmentally friendly shopping recommendations. This repository currently acts as a placeholder for future development.
+
+## Free vs. Premium Features
+
+The initial release of EcoShopper will provide a free tier that allows users to search for and bookmark sustainable products. A premium subscription is planned that will unlock additional capabilities such as personalized analytics, priority support, and an ad‑free experience.
+
+### Ad Integration Plans
+
+The service is exploring the possibility of displaying advertisements from sustainable brands in the free tier. Any ads will be non‑intrusive and clearly labeled to maintain transparency with our users.
+
+## Deploying the Backend
+
+For development, the backend can be launched with a command such as:
+
+```bash
+uvicorn app:app --reload
+```
+
+A production deployment might use `gunicorn` with `uvicorn` workers:
+
+```bash
+gunicorn app:app -k uvicorn.workers.UvicornWorker
+```
+
+These commands assume an ASGI application named `app` is available.
+
+## Serving the Frontend
+
+When a frontend is ready, build the static files and serve them using a simple HTTP server. For example:
+
+```bash
+npm install
+npm run build
+npx serve -s build
+```
+
+This will host the compiled frontend on the default port.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Welcome to EcoShopper"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>EcoShopper</title>
+</head>
+<body>
+    <h1>EcoShopper Frontend Placeholder</h1>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ecoshopper-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "echo \"building frontend\"",
+    "serve": "npx serve -s build"
+  }
+}


### PR DESCRIPTION
## Summary
- document free vs. premium tiers and plans for ads
- add backend and frontend deployment instructions
- create minimal backend and frontend placeholders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aa4f10fb083249e0b5895793dca9d